### PR TITLE
Download only the labeled dataset images

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1,7 +1,8 @@
 [google_cloud]
 project = "project-id" # The project ID can be found in the GCP console https://console.cloud.google.com/
-bucket = "destination-bucket-name" # The bucket where the output data will be stored. Should follow the format "gs://bucket-name".
-images_bucket = "source-images-bucket-name" # The bucket containing the input images. Should follow the format "gs://bucket-name/folder".
+trained_models_bucket = "trained-models-bucket-name" # The bucket name where the output data will be stored.
+source_images_bucket = "source-images-bucket-name" # The bucket name containing the input images for training.
+source_images_directory = "source-images-directory" # The directory containing the input images for training, inside the source images bucket.
 
 [vertex_ai_machine_config]
 machine_type = "n1-standard-4" # The type of machine to use. Refer to: https://cloud.google.com/vertex-ai/docs/training/configure-compute#machine-types
@@ -9,7 +10,8 @@ accelerator_type = "NVIDIA_TESLA_T4" # The type of accelerator to use. Refer to:
 accelerator_count = 1 # Number of accelerators
 
 [label_studio]
-project_url = "project-url" # This is the project API URL, for example: "https://label-studio.example.com/api/projects/1"
+project_id = 1 # The ID of the Label Studio project, can be found in the URL of the project page.
+url = "https://label-studio.k8s.eryx.co/"
 token = "token" # The token to authenticate with the Label Studio API, refer to: https://api.labelstud.io/api-reference/introduction/getting-started#authentication
 
 [training]

--- a/remote_training/train_requirements.txt
+++ b/remote_training/train_requirements.txt
@@ -5,3 +5,4 @@ PyYAML==6.0.1
 label-studio-sdk==1.0.3
 ray[tune]==2.32.0
 # mlflow==2.13.1
+google-cloud-storage==2.17.0

--- a/remote_training/training_script.py
+++ b/remote_training/training_script.py
@@ -1,6 +1,5 @@
 import datetime
 import gc
-import json
 import logging
 import os
 import shutil
@@ -19,6 +18,8 @@ from sklearn.model_selection import KFold
 os.environ["RANK"] = "-1"
 from ultralytics import YOLO
 from label_studio_sdk.converter import Converter
+from label_studio_sdk import Client as LabelStudioClient
+from google.cloud import storage
 
 
 class TrainingScript:
@@ -27,32 +28,39 @@ class TrainingScript:
         self.epochs = int(os.environ["EPOCHS"])
         self.model = os.environ["MODEL"]
         self.obb = os.environ["OBB"] == "True"
-        self.label_studio_token = os.environ["LABEL_STUDIO_TOKEN"]
-        self.label_studio_project_url = os.environ["LABEL_STUDIO_PROJECT_URL"]
-        self.images_bucket_path = os.environ["IMAGES_BUCKET_PATH"]
         self.base_path = os.getcwd()
-        self.bucket_path = os.environ["BUCKET_PATH"]
         self.dataset_path = Path("dataset")
         self.number_folds = int(os.environ["NUMBER_OF_FOLDS"])
         self.use_kfold = (os.environ["USE_KFOLD"] == "True")
         self.save_path = self._define_save_path()
-        self.accelerator_count = int(os.environ["ACCELERATOR_COUNT"])
-        self.rank = os.environ["RANK"]
         self.training_results_path = self.save_path / "training_results"
         self.fold_datasets_path = self.save_path / "folds_datasets"
         self.single_dataset_path = self.save_path / "single_dataset"
         self.mlflow_experiment_name = os.environ["MLFLOW_EXPERIMENT_NAME"]
+        self.accelerator_count = int(os.environ["ACCELERATOR_COUNT"])
+        self.rank = os.environ["RANK"]
+
+        self.label_studio_url = os.environ["LABEL_STUDIO_URL"]
+        self.label_studio_token = os.environ["LABEL_STUDIO_TOKEN"]
+        self.label_studio_project_id = int(os.environ["LABEL_STUDIO_PROJECT_ID"])
+        label_studio = LabelStudioClient(url=self.label_studio_url, api_key=self.label_studio_token)
+        self.label_studio_project = label_studio.get_project(self.label_studio_project_id)
+
+        google_cloud_client = storage.Client()
+        self.source_images_bucket = google_cloud_client.get_bucket(os.environ["SOURCE_IMAGES_BUCKET"])
+        self.source_images_directory = Path(os.environ["SOURCE_IMAGES_DIRECTORY"])
+        self.trained_models_bucket_name = os.environ['TRAINED_MODELS_BUCKET']
 
     def run(self):
         self._check_if_gpu_is_available()
         self._prevent_multi_gpu_training()
 
-        class_names, images, annotations = self._download_dataset()
-        images, annotations = self._match_images_and_annotations(images, annotations)
-        datasets_path = self.fold_datasets_path if self.use_kfold else self.single_dataset_path
+        class_names, annotations = self._download_dataset_annotations()
+        images = self._download_labeled_dataset_images()
 
         if self.use_kfold:
-            dataset_yaml_list = self._create_k_folds(annotations, class_names, images, datasets_path)
+            dataset_path = self.fold_datasets_path
+            dataset_yaml_list = self._create_k_folds(annotations, class_names, images, dataset_path)
             for fold_number in range(len(dataset_yaml_list)):
                 dataset_yaml = dataset_yaml_list[fold_number]
                 model_name = self._fold_name(fold_number)
@@ -60,27 +68,223 @@ class TrainingScript:
                 self._save_model_metrics(model_name, model)
                 self._clean_gpu_cache()  # This is necessary to avoid running out of memory
         else:
-            dataset_yaml = self._create_single_dataset(annotations, class_names, images, datasets_path)
+            dataset_path = self.single_dataset_path
+            dataset_yaml = self._create_single_dataset(annotations, class_names, images, dataset_path)
             model_name = "single_model"
             model = self._train_model(dataset_yaml, model_name)
             self._save_model_metrics(model_name, model)
 
         self._export_results()
 
-    def _export_results(self):
-        os.system(f'gsutil -m cp -r "{self.save_path}" "{self.bucket_path}"')
+    def _define_save_path(self):
+        formatted_datetime = datetime.datetime.now().isoformat().replace('.', '').replace(':', '')
+        if self.use_kfold:
+            return Path(self.dataset_path / f"{formatted_datetime}_{self.number_folds}-Fold_Cross-val")
+        else:
+            return Path(self.dataset_path / f"{formatted_datetime}_Single_Model_Training")
 
-    def _save_model_metrics(self, fold_name, model):
-        metrics = model.metrics.box
-        results = pd.DataFrame(
-            {
-                "p": metrics.p,
-                "r": metrics.r,
-                "map50": metrics.ap50,
-                "map50-95": metrics.ap,
-            }
+    # GPU
+
+    def _check_if_gpu_is_available(self):
+        gpu_available = torch.cuda.is_available()
+        logging.info(f"Checking if GPU is available: {gpu_available}")
+        if self.accelerator_count > 0 and not gpu_available:
+            logging.error(f"GPU is not available, accelerator count: {self.accelerator_count}")
+            exit(1)
+        return gpu_available
+
+    def _prevent_multi_gpu_training(self):
+        logging.info(f"Checking RANK: {self.rank}")
+        if self.rank != "-1":
+            logging.error("Trying multi gpu training. Exiting.")
+            exit(1)
+
+    def _clean_gpu_cache(self):
+        if self._check_if_gpu_is_available():
+            torch.cuda.empty_cache()
+            gc.collect()
+
+    # Dataset
+
+    def _download_dataset_annotations(self):
+        self.dataset_path.mkdir(parents=True, exist_ok=True)
+        self.save_path.mkdir(parents=True, exist_ok=True)
+
+        if self.obb:
+            json_annotations_path = self.dataset_path / 'annotations.json'
+            self._export_annotations_from_label_studio("JSON", json_annotations_path)
+            self._convert_annotations_into_yolo_obb(json_annotations_path, self.dataset_path)
+        else:
+            yolo_annotations_path = self.dataset_path / "annotations.zip"
+            self._export_annotations_from_label_studio("YOLO", yolo_annotations_path)
+            shutil.unpack_archive(yolo_annotations_path, extract_dir=self.dataset_path)
+
+        with open(f"{self.dataset_path}/classes.txt", "r") as f:
+            class_names = f.read().splitlines()
+        yaml_data = {
+            "names": class_names,
+            "nc": len(class_names),
+            "train": f"{self.base_path}/{self.dataset_path}/train",
+            "val": f"{self.base_path}/{self.dataset_path}/val",
+        }
+        yaml_file_path = f"{self.dataset_path}/data.yaml"
+        with open(yaml_file_path, "w") as yaml_file:
+            yaml.dump(yaml_data, yaml_file, default_flow_style=False)
+
+        labels_path = self.dataset_path / "labels"
+        annotations = sorted(labels_path.rglob("*.txt"))
+        return class_names, annotations
+
+    def _export_annotations_from_label_studio(self, export_type, output_path):
+        os.system(
+            f"curl -X GET {self.label_studio_url}api/projects/{self.label_studio_project_id}/export\?exportType\={export_type} \
+            -H 'Authorization: Token {self.label_studio_token}' --output '{str(output_path)}'"
         )
-        results.to_csv(f"{self.training_results_path}/{fold_name}/metrics.csv")
+
+    def _convert_annotations_into_yolo_obb(self, json_annotations_path, output_dir_path):
+        label_config = self.label_studio_project.parsed_label_config
+
+        converter = Converter(config=label_config, project_dir='.')
+        converter.convert_to_yolo(
+            input_data=str(json_annotations_path),
+            is_dir=False,
+            output_dir=str(output_dir_path),
+            is_obb=True)
+
+    def _download_labeled_dataset_images(self):
+        labeled_tasks = self.label_studio_project.get_labeled_tasks()
+        labeled_image_names = list(map(lambda task:
+                                       Path(task['data']['image']).name,
+                                       labeled_tasks))
+
+        all_dataset_image_paths = []
+        for image_name in labeled_image_names:
+            source_image_path = self.source_images_directory / image_name
+            destination_image_path = self.dataset_path / image_name
+            all_dataset_image_paths.append(destination_image_path)
+
+            google_cloud_image = self.source_images_bucket.blob(str(source_image_path))
+            google_cloud_image.download_to_filename(destination_image_path)
+
+        return sorted(all_dataset_image_paths)
+
+    def _create_single_dataset(self, annotations, class_names, images, datasets_path):
+        folder_name = 'single_dataset'
+        model_info_dir = datasets_path / folder_name
+        model_info_dir.mkdir(parents=True, exist_ok=True)
+        (model_info_dir / "train" / "images").mkdir(parents=True, exist_ok=True)
+        (model_info_dir / "train" / "labels").mkdir(parents=True, exist_ok=True)
+        (model_info_dir / "val" / "images").mkdir(parents=True, exist_ok=True)
+        (model_info_dir / "val" / "labels").mkdir(parents=True, exist_ok=True)
+
+        dataset_yaml = model_info_dir / f"dataset.yaml"
+
+        with open(dataset_yaml, "w") as ds_y:
+            yaml.safe_dump(
+                {
+                    "path": f"{self.base_path}/{model_info_dir.as_posix()}",
+                    "train": "train",
+                    "val": "val",
+                    "names": class_names,
+                },
+                ds_y,
+            )
+        for image, label in zip(images, annotations):
+            shutil.copy(image, datasets_path / folder_name / 'train' / "images" / image.name)
+            shutil.copy(label, datasets_path / folder_name / 'train' / "labels" / label.name)
+
+        first_image = images[0]
+        first_label = annotations[0]
+        shutil.copy(first_image, datasets_path / folder_name / 'val' / "images" / first_image.name)
+        shutil.copy(first_label, datasets_path / folder_name / 'val' / "labels" / first_label.name)
+        return dataset_yaml
+
+    def _create_k_folds(self, annotations, class_names, images, datasets_path):
+        file_names = [annotation.stem for annotation in annotations]
+        class_indices = list(range(len(class_names)))
+
+        labels_per_image = self._build_df_with_labels_per_image(annotations, class_indices, file_names)
+
+        # It's necessary to cast to list because a generator can only be used once, and we use it many times.
+        k_fold_indices = list(KFold(n_splits=self.number_folds, shuffle=True, random_state=20).split(labels_per_image))
+
+        fold_names = [self._fold_name(n) for n in range(self.number_folds)]
+        folds_df = self._build_df_with_image_distribution_for_folds(k_fold_indices, labels_per_image, file_names,
+                                                                    fold_names)
+        fold_label_distribution = self._build_df_with_label_distribution_for_folds(fold_names, class_indices,
+                                                                                   k_fold_indices, labels_per_image)
+        folds_yamls = self._build_train_and_val_dataset_yaml(folds_df, class_names, datasets_path)
+        self._build_datasets_folders(folds_df, datasets_path)
+        self._copy_images_and_labels_to_datasets(annotations, datasets_path, folds_df, images)
+        folds_df.to_csv(datasets_path / "kfold_datasplit.csv")
+        fold_label_distribution.to_csv(datasets_path / "kfold_label_distribution.csv")
+        return folds_yamls
+
+    def _build_df_with_labels_per_image(self, annotations, class_indices, file_names):
+        labels_per_image = pd.DataFrame([], columns=class_indices, index=file_names)
+        for label in annotations:
+            label_counter = Counter()
+            with open(label, "r") as lf:
+                lines = lf.readlines()
+            for line in lines:
+                label_counter[int(line.split(" ")[0])] += 1
+            labels_per_image.loc[label.stem] = label_counter
+        return labels_per_image.fillna(0.0)
+
+    def _fold_name(self, k):
+        return f"fold_{k + 1}"
+
+    def _build_df_with_image_distribution_for_folds(self, k_fold_indices, labels_per_image, file_names, fold_names):
+        folds_df = pd.DataFrame(index=file_names, columns=fold_names)
+
+        for index, (train, val) in enumerate(k_fold_indices):
+            folds_df[self._fold_name(index)].loc[labels_per_image.iloc[train].index] = "train"
+            folds_df[self._fold_name(index)].loc[labels_per_image.iloc[val].index] = "val"
+        return folds_df
+
+    def _build_df_with_label_distribution_for_folds(self, fold_names, class_indices, k_fold_indices, labels_per_image):
+        fold_label_distribution = pd.DataFrame(index=fold_names, columns=class_indices)
+        for n, (train_indices, val_indices) in enumerate(k_fold_indices):
+            train_totals = labels_per_image.iloc[train_indices].sum()
+            val_totals = labels_per_image.iloc[val_indices].sum()
+            ratio = val_totals / (train_totals + 1e-7)
+            fold_label_distribution.loc[self._fold_name(n)] = ratio
+        return fold_label_distribution
+
+    def _build_train_and_val_dataset_yaml(self, folds_df, class_names, datasets_path):
+        folds_yamls = []
+        for fold in folds_df.columns:
+            fold_dir = datasets_path / fold
+            fold_dir.mkdir(parents=True, exist_ok=True)
+            dataset_yaml = fold_dir / f"dataset.yaml"
+            with open(dataset_yaml, "w") as ds_y:
+                yaml.safe_dump(
+                    {
+                        "path": f"{self.base_path}/{fold_dir.as_posix()}",
+                        "train": "train",
+                        "val": "val",
+                        "names": class_names,
+                    },
+                    ds_y,
+                )
+            folds_yamls.append(dataset_yaml)
+        return folds_yamls
+
+    def _build_datasets_folders(self, folds_df, datasets_path):
+        for fold in folds_df.columns:
+            fold_dir = datasets_path / fold
+            (fold_dir / "train" / "images").mkdir(parents=True, exist_ok=True)
+            (fold_dir / "train" / "labels").mkdir(parents=True, exist_ok=True)
+            (fold_dir / "val" / "images").mkdir(parents=True, exist_ok=True)
+            (fold_dir / "val" / "labels").mkdir(parents=True, exist_ok=True)
+
+    def _copy_images_and_labels_to_datasets(self, annotations, datasets_path, folds_df, images):
+        for image, label in zip(images, annotations):
+            for fold, train_or_val in folds_df.loc[image.stem].items():
+                shutil.copy(image, datasets_path / fold / train_or_val / "images" / image.name)
+                shutil.copy(label, datasets_path / fold / train_or_val / "labels" / label.name)
+
+    # Training
 
     def _train_model(self, dataset_yaml, model_name):
         augmentations = self._augmentations()
@@ -122,211 +326,23 @@ class TrainingScript:
         }
         return augmentations
 
-    def _create_k_folds(self, annotations, class_names, images, datasets_path):
-        file_names = [annotation.stem for annotation in annotations]
-        class_indices = list(range(len(class_names)))
-
-        labels_per_image = self._build_df_with_labels_per_image(annotations, class_indices, file_names)
-
-        # It's necessary to cast to list because a generator can only be used once, and we use it many times.
-        k_fold_indices = list(KFold(n_splits=self.number_folds, shuffle=True, random_state=20).split(labels_per_image))
-
-        fold_names = [self._fold_name(n) for n in range(self.number_folds)]
-        folds_df = self._build_df_with_image_distribution_for_folds(k_fold_indices, labels_per_image, file_names,
-                                                                    fold_names)
-        fold_label_distribution = self._build_df_with_label_distribution_for_folds(fold_names, class_indices,
-                                                                                   k_fold_indices, labels_per_image)
-        folds_yamls = self._build_train_and_val_dataset_yaml(folds_df, class_names, datasets_path)
-        self._build_datasets_folders(folds_df, datasets_path)
-        self._copy_images_and_labels_to_datasets(annotations, datasets_path, folds_df, images)
-        folds_df.to_csv(datasets_path / "kfold_datasplit.csv")
-        fold_label_distribution.to_csv(datasets_path / "kfold_label_distribution.csv")
-        return folds_yamls
-
-    def _build_train_and_val_dataset_yaml(self, folds_df, class_names, datasets_path):
-        folds_yamls = []
-        for fold in folds_df.columns:
-            fold_dir = datasets_path / fold
-            fold_dir.mkdir(parents=True, exist_ok=True)
-            dataset_yaml = fold_dir / f"dataset.yaml"
-            with open(dataset_yaml, "w") as ds_y:
-                yaml.safe_dump(
-                    {
-                        "path": f"{self.base_path}/{fold_dir.as_posix()}",
-                        "train": "train",
-                        "val": "val",
-                        "names": class_names,
-                    },
-                    ds_y,
-                )
-            folds_yamls.append(dataset_yaml)
-        return folds_yamls
-
-    def _build_datasets_folders(self, folds_df, datasets_path):
-        for fold in folds_df.columns:
-            fold_dir = datasets_path / fold
-            (fold_dir / "train" / "images").mkdir(parents=True, exist_ok=True)
-            (fold_dir / "train" / "labels").mkdir(parents=True, exist_ok=True)
-            (fold_dir / "val" / "images").mkdir(parents=True, exist_ok=True)
-            (fold_dir / "val" / "labels").mkdir(parents=True, exist_ok=True)
-
-    def _copy_images_and_labels_to_datasets(self, annotations, datasets_path, folds_df, images):
-        for image, label in zip(images, annotations):
-            for fold, train_or_val in folds_df.loc[image.stem].items():
-                shutil.copy(image, datasets_path / fold / train_or_val / "images" / image.name)
-                shutil.copy(label, datasets_path / fold / train_or_val / "labels" / label.name)
-
-    def _create_single_dataset(self, annotations, class_names, images, datasets_path):
-        folder_name = 'single_dataset'
-        model_info_dir = datasets_path / folder_name
-        model_info_dir.mkdir(parents=True, exist_ok=True)
-        (model_info_dir / "train" / "images").mkdir(parents=True, exist_ok=True)
-        (model_info_dir / "train" / "labels").mkdir(parents=True, exist_ok=True)
-        (model_info_dir / "val" / "images").mkdir(parents=True, exist_ok=True)
-        (model_info_dir / "val" / "labels").mkdir(parents=True, exist_ok=True)
-
-        dataset_yaml = model_info_dir / f"dataset.yaml"
-
-        with open(dataset_yaml, "w") as ds_y:
-            yaml.safe_dump(
-                {
-                    "path": f"{self.base_path}/{model_info_dir.as_posix()}",
-                    "train": "train",
-                    "val": "val",
-                    "names": class_names,
-                },
-                ds_y,
-            )
-        for image, label in zip(images, annotations):
-            shutil.copy(image, datasets_path / folder_name / 'train' / "images" / image.name)
-            shutil.copy(label, datasets_path / folder_name / 'train' / "labels" / label.name)
-
-        first_image = images[0]
-        first_label = annotations[0]
-        shutil.copy(first_image, datasets_path / folder_name / 'val' / "images" / first_image.name)
-        shutil.copy(first_label, datasets_path / folder_name / 'val' / "labels" / first_label.name)
-        return dataset_yaml
-
-    def _download_dataset(self):
-        self.dataset_path.mkdir(parents=True, exist_ok=True)
-        self.save_path.mkdir(parents=True, exist_ok=True)
-        os.system(f'gsutil -m cp -r "{self.images_bucket_path}" {str(self.dataset_path)}')
-        if self.obb:
-            json_annotations_path = self.dataset_path / 'annotations.json'
-            self._export_annotations_from_label_studio("JSON", json_annotations_path)
-
-            print("Converting annotations to YOLO OBB format.")
-            self._convert_annotations_into_yolo_obb(json_annotations_path, self.dataset_path)
-        else:
-            self._export_annotations_from_label_studio("YOLO", "annotations.zip")
-            os.system(f"unzip -o annotations -d {str(self.dataset_path)}")
-
-        with open(f"{self.dataset_path}/classes.txt", "r") as f:
-            class_names = f.read().splitlines()
-        yaml_data = {
-            "names": class_names,
-            "nc": len(class_names),
-            "train": f"{self.base_path}/{self.dataset_path}/train",
-            "val": f"{self.base_path}/{self.dataset_path}/val",
-        }
-        yaml_file_path = f"{self.dataset_path}/data.yaml"
-        with open(yaml_file_path, "w") as yaml_file:
-            yaml.dump(yaml_data, yaml_file, default_flow_style=False)
-        annotations = sorted(self.dataset_path.rglob("*labels/*.txt"))
-        images = []
-        images_path = self.images_bucket_path.split("/")[-1]
-        for extension in [".jpg", ".jpeg", ".png"]:
-            images.extend(sorted((self.dataset_path / images_path).rglob(f"*{extension}")))
-        return class_names, images, annotations
-
-    def _export_annotations_from_label_studio(self, export_type, output_path):
-        os.system(
-            f"curl -X GET {self.label_studio_project_url}/export\?exportType\={export_type} -H 'Authorization: Token {self.label_studio_token}' --output '{str(output_path)}'"
-        )
-
-    def _convert_annotations_into_yolo_obb(self, json_annotations_path, output_dir_path):
-        label_config_path = str(self.dataset_path / 'label_config.json')
-        os.system(
-            f"curl -X GET {self.label_studio_project_url}/validate -H 'Authorization: Token {self.label_studio_token}' --output '{label_config_path}'"
-        )
-        with open(f"{label_config_path}", "r") as f:
-            raw_data = f.read()
-            data_as_json = json.loads(raw_data)
-            label_config = data_as_json['label_config']
-
-        converter = Converter(config=label_config, project_dir='.')
-        converter.convert_to_yolo(
-            input_data=str(json_annotations_path),
-            is_dir=False,
-            output_dir=str(output_dir_path),
-            is_obb=True)
-
-    def _prevent_multi_gpu_training(self):
-        logging.info(f"Checking RANK: {self.rank}")
-        if self.rank != "-1":
-            logging.error("Trying multi gpu training. Exiting.")
-            exit(1)
-
-    def _check_if_gpu_is_available(self):
-        gpu_available = torch.cuda.is_available()
-        logging.info(f"Checking if GPU is available: {gpu_available}")
-        if self.accelerator_count > 0 and not gpu_available:
-            logging.error(f"GPU is not available, accelerator count: {self.accelerator_count}")
-            exit(1)
-        return gpu_available
-
-    def _fold_name(self, k):
-        return f"fold_{k + 1}"
-
     def _get_device(self):
         return '0' if self._check_if_gpu_is_available() else 'cpu'
 
-    def _define_save_path(self):
-        formatted_datetime = datetime.datetime.now().isoformat().replace('.', '').replace(':', '')
-        if self.use_kfold:
-            return Path(self.dataset_path / f"{formatted_datetime}_{self.number_folds}-Fold_Cross-val")
-        else:
-            return Path(self.dataset_path / f"{formatted_datetime}_Single_Model_Training")
+    def _save_model_metrics(self, fold_name, model):
+        metrics = model.metrics.box
+        results = pd.DataFrame(
+            {
+                "p": metrics.p,
+                "r": metrics.r,
+                "map50": metrics.ap50,
+                "map50-95": metrics.ap,
+            }
+        )
+        results.to_csv(f"{self.training_results_path}/{fold_name}/metrics.csv")
 
-    def _build_df_with_labels_per_image(self, annotations, class_indices, file_names):
-        labels_per_image = pd.DataFrame([], columns=class_indices, index=file_names)
-        for label in annotations:
-            label_counter = Counter()
-            with open(label, "r") as lf:
-                lines = lf.readlines()
-            for line in lines:
-                label_counter[int(line.split(" ")[0])] += 1
-            labels_per_image.loc[label.stem] = label_counter
-        return labels_per_image.fillna(0.0)
-
-    def _build_df_with_image_distribution_for_folds(self, k_fold_indices, labels_per_image, file_names, fold_names):
-        folds_df = pd.DataFrame(index=file_names, columns=fold_names)
-
-        for index, (train, val) in enumerate(k_fold_indices):
-            folds_df[self._fold_name(index)].loc[labels_per_image.iloc[train].index] = "train"
-            folds_df[self._fold_name(index)].loc[labels_per_image.iloc[val].index] = "val"
-        return folds_df
-
-    def _build_df_with_label_distribution_for_folds(self, fold_names, class_indices, k_fold_indices, labels_per_image):
-        fold_label_distribution = pd.DataFrame(index=fold_names, columns=class_indices)
-        for n, (train_indices, val_indices) in enumerate(k_fold_indices):
-            train_totals = labels_per_image.iloc[train_indices].sum()
-            val_totals = labels_per_image.iloc[val_indices].sum()
-            ratio = val_totals / (train_totals + 1e-7)
-            fold_label_distribution.loc[self._fold_name(n)] = ratio
-        return fold_label_distribution
-
-    def _match_images_and_annotations(self, images, annotations):
-        annotations_stems = [annotation.stem for annotation in annotations]
-        images_stems = [image.stem for image in images]
-        images_with_annotation = [image for image in images if image.stem in annotations_stems]
-        annotations_with_image = [annotation for annotation in annotations if annotation.stem in images_stems]
-        return images_with_annotation, annotations_with_image
-
-    def _clean_gpu_cache(self):
-        if self._check_if_gpu_is_available():
-            torch.cuda.empty_cache()
-            gc.collect()
+    def _export_results(self):
+        os.system(f'gsutil -m cp -r "{self.save_path}" "gs://{self.trained_models_bucket_name}"')
 
 
 if __name__ == "__main__":

--- a/src/cli.py
+++ b/src/cli.py
@@ -60,27 +60,29 @@ class CLI:
     def _training_config(self, config):
         return TrainingConfig(
             label_studio_token=config["label_studio"]["token"],
-            label_studio_project_url=config["label_studio"]["project_url"],
+            label_studio_url=config["label_studio"]["url"],
+            label_studio_project_id=config["label_studio"]["project_id"],
             image_size=config["training"]["image_size"],
             epochs=config["training"]["epochs"],
             model=config["training"]["model"],
             obb=config["training"]["obb"],
             number_of_folds=config["training"]["number_of_folds"],
-            images_bucket_path=config["google_cloud"]["images_bucket"],
-            bucket_path=config["google_cloud"]["bucket"],
             use_kfold=config["training"]["use_kfold"],
             accelerator_count=config["vertex_ai_machine_config"]["accelerator_count"],
             mlflow_tracking_uri=config["mlflow"]["tracking_uri"],
             mlflow_experiment_name=config["mlflow"]["experiment_name"],
             mlflow_run=config["mlflow"]["run"],
             mlflow_tracking_username=config["mlflow"]["user"],
-            mlflow_tracking_password=config["mlflow"]["password"]
+            mlflow_tracking_password=config["mlflow"]["password"],
+            source_images_bucket=config["google_cloud"]["source_images_bucket"],
+            source_images_directory=config["google_cloud"]["source_images_directory"],
+            trained_models_bucket=config["google_cloud"]["trained_models_bucket"],
         )
 
     def _run_remote(self, config, training_config):
         train_job = TrainingJob(
             gc_project=config["google_cloud"]["project"],
-            gc_bucket=config["google_cloud"]["bucket"],
+            gc_bucket=config["google_cloud"]["trained_models_bucket"],
             machine_type=config["vertex_ai_machine_config"]["machine_type"],
             accelerator_type=config["vertex_ai_machine_config"]["accelerator_type"],
             accelerator_count=config["vertex_ai_machine_config"]["accelerator_count"],
@@ -97,15 +99,15 @@ class CLI:
         train_script.run()
 
     def _load_environment_variables(self, training_config):
+        # This code is repeated with #_load_environment_variables in TrainingJob
         return {
             "IMAGE_SIZE": str(training_config.image_size),
             "EPOCHS": str(training_config.epochs),
             "MODEL": str(training_config.model),
             "OBB": str(training_config.obb),
             "LABEL_STUDIO_TOKEN": str(training_config.label_studio_token),
-            "LABEL_STUDIO_PROJECT_URL": str(training_config.label_studio_project_url),
-            "IMAGES_BUCKET_PATH": str(training_config.images_bucket_path),
-            "BUCKET_PATH": str(training_config.bucket_path),
+            "LABEL_STUDIO_URL": str(training_config.label_studio_url),
+            "LABEL_STUDIO_PROJECT_ID": str(training_config.label_studio_project_id),
             "NUMBER_OF_FOLDS": str(training_config.number_of_folds),
             "USE_KFOLD": str(training_config.use_kfold),
             "ACCELERATOR_COUNT": str(training_config.accelerator_count),
@@ -113,7 +115,10 @@ class CLI:
             "MLFLOW_EXPERIMENT_NAME": str(training_config.mlflow_experiment_name),
             "MLFLOW_RUN": str(training_config.mlflow_run),
             "MLFLOW_TRACKING_USERNAME": str(training_config.mlflow_tracking_username),
-            "MLFLOW_TRACKING_PASSWORD": str(training_config.mlflow_tracking_password)
+            "MLFLOW_TRACKING_PASSWORD": str(training_config.mlflow_tracking_password),
+            "SOURCE_IMAGES_BUCKET": str(training_config.source_images_bucket),
+            "SOURCE_IMAGES_DIRECTORY": str(training_config.source_images_directory),
+            "TRAINED_MODELS_BUCKET": str(training_config.trained_models_bucket),
         }
 
 
@@ -124,9 +129,8 @@ class TrainingConfig:
     model: str
     obb: bool
     label_studio_token: str
-    label_studio_project_url: str
-    images_bucket_path: str
-    bucket_path: str
+    label_studio_url: str
+    label_studio_project_id: str
     number_of_folds: int
     use_kfold: bool
     accelerator_count: int
@@ -135,6 +139,9 @@ class TrainingConfig:
     mlflow_run: str
     mlflow_tracking_username: str
     mlflow_tracking_password: str
+    source_images_bucket: str
+    source_images_directory: str
+    trained_models_bucket: str
 
 
 def main():

--- a/src/training_job.py
+++ b/src/training_job.py
@@ -14,7 +14,7 @@ class TrainingJob:
         self.accelerator_count = accelerator_count
         self.training_config = training_config
 
-        aiplatform.init(project=self.gc_project, staging_bucket=self.gc_bucket)
+        aiplatform.init(project=self.gc_project, staging_bucket=f"gs://{self.gc_bucket}")
 
         self.job = aiplatform.CustomTrainingJob(
             display_name=self.DEFAULT_JOB_NAME,
@@ -40,9 +40,8 @@ class TrainingJob:
             "MODEL": str(training_config.model),
             "OBB": str(training_config.obb),
             "LABEL_STUDIO_TOKEN": str(training_config.label_studio_token),
-            "LABEL_STUDIO_PROJECT_URL": str(training_config.label_studio_project_url),
-            "IMAGES_BUCKET_PATH": str(training_config.images_bucket_path),
-            "BUCKET_PATH": str(training_config.bucket_path),
+            "LABEL_STUDIO_URL": str(training_config.label_studio_url),
+            "LABEL_STUDIO_PROJECT_ID": str(training_config.label_studio_project_id),
             "NUMBER_OF_FOLDS": str(training_config.number_of_folds),
             "ACCELERATOR_COUNT": str(training_config.accelerator_count),
             "USE_KFOLD": str(training_config.use_kfold),
@@ -50,7 +49,10 @@ class TrainingJob:
             "MLFLOW_EXPERIMENT_NAME": str(training_config.mlflow_experiment_name),
             "MLFLOW_RUN": str(training_config.mlflow_run),
             "MLFLOW_TRACKING_USERNAME": str(training_config.mlflow_tracking_username),
-            "MLFLOW_TRACKING_PASSWORD": str(training_config.mlflow_tracking_password)
+            "MLFLOW_TRACKING_PASSWORD": str(training_config.mlflow_tracking_password),
+            "SOURCE_IMAGES_BUCKET": str(training_config.source_images_bucket),
+            "SOURCE_IMAGES_DIRECTORY": str(training_config.source_images_directory),
+            "TRAINED_MODELS_BUCKET": str(training_config.trained_models_bucket),
         }
 
     def _load_requirements(self) -> list[str]:


### PR DESCRIPTION
Now only the labeled images are downloaded from the bucket, instead of downloading ALL images and then filtering the labeled ones. This is faster when there are many images on the bucket.

Some `os` calls were also replaced by calls to libraries, which is faster and less prone to errors. Specifically for decompressing the YOLO zip file, and for getting the label config from LabelStudio.

Methods were also reordered and categorized.