### PR TITLE
Download only the labeled dataset images

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1,7 +1,8 @@
 [google_cloud]
 project = "project-id" # The project ID can be found in the GCP console https://console.cloud.google.com/
-bucket = "destination-bucket-name" # The bucket where the output data will be stored. Should follow the format "gs://bucket-name".
-images_bucket = "source-images-bucket-name" # The bucket containing the input images. Should follow the format "gs://bucket-name/folder".
+trained_models_bucket = "trained-models-bucket-name" # The bucket name where the output data will be stored.
+source_images_bucket = "source-images-bucket-name" # The bucket name containing the input images for training.
+source_images_directory = "source-images-directory" # The directory containing the input images for training, inside the source images bucket.
 
 [vertex_ai_machine_config]
 machine_type = "n1-standard-4" # The type of machine to use. Refer to: https://cloud.google.com/vertex-ai/docs/training/configure-compute#machine-types
@@ -9,7 +10,8 @@ accelerator_type = "NVIDIA_TESLA_T4" # The type of accelerator to use. Refer to:
 accelerator_count = 1 # Number of accelerators
 
 [label_studio]
-project_url = "project-url" # This is the project API URL, for example: "https://label-studio.example.com/api/projects/1"
+project_id = 1 # The ID of the Label Studio project, can be found in the URL of the project page.
+url = "https://label-studio.k8s.eryx.co/" # The URL of the Label Studio instance (with an ending /).
 token = "token" # The token to authenticate with the Label Studio API, refer to: https://api.labelstud.io/api-reference/introduction/getting-started#authentication
 
 [training]

--- a/remote_training/train_requirements.txt
+++ b/remote_training/train_requirements.txt
@@ -5,3 +5,4 @@ PyYAML==6.0.1
 label-studio-sdk==1.0.3
 ray[tune]==2.32.0
 # mlflow==2.13.1
+google-cloud-storage==2.17.0

--- a/src/cli.py
+++ b/src/cli.py
@@ -60,27 +60,29 @@ class CLI:
     def _training_config(self, config):
         return TrainingConfig(
             label_studio_token=config["label_studio"]["token"],
-            label_studio_project_url=config["label_studio"]["project_url"],
+            label_studio_url=config["label_studio"]["url"],
+            label_studio_project_id=config["label_studio"]["project_id"],
             image_size=config["training"]["image_size"],
             epochs=config["training"]["epochs"],
             model=config["training"]["model"],
             obb=config["training"]["obb"],
             number_of_folds=config["training"]["number_of_folds"],
-            images_bucket_path=config["google_cloud"]["images_bucket"],
-            bucket_path=config["google_cloud"]["bucket"],
             use_kfold=config["training"]["use_kfold"],
             accelerator_count=config["vertex_ai_machine_config"]["accelerator_count"],
             mlflow_tracking_uri=config["mlflow"]["tracking_uri"],
             mlflow_experiment_name=config["mlflow"]["experiment_name"],
             mlflow_run=config["mlflow"]["run"],
             mlflow_tracking_username=config["mlflow"]["user"],
-            mlflow_tracking_password=config["mlflow"]["password"]
+            mlflow_tracking_password=config["mlflow"]["password"],
+            source_images_bucket=config["google_cloud"]["source_images_bucket"],
+            source_images_directory=config["google_cloud"]["source_images_directory"],
+            trained_models_bucket=config["google_cloud"]["trained_models_bucket"],
         )
 
     def _run_remote(self, config, training_config):
         train_job = TrainingJob(
             gc_project=config["google_cloud"]["project"],
-            gc_bucket=config["google_cloud"]["bucket"],
+            gc_bucket=config["google_cloud"]["trained_models_bucket"],
             machine_type=config["vertex_ai_machine_config"]["machine_type"],
             accelerator_type=config["vertex_ai_machine_config"]["accelerator_type"],
             accelerator_count=config["vertex_ai_machine_config"]["accelerator_count"],
@@ -97,15 +99,15 @@ class CLI:
         train_script.run()
 
     def _load_environment_variables(self, training_config):
+        # This code is repeated with #_load_environment_variables in TrainingJob
         return {
             "IMAGE_SIZE": str(training_config.image_size),
             "EPOCHS": str(training_config.epochs),
             "MODEL": str(training_config.model),
             "OBB": str(training_config.obb),
             "LABEL_STUDIO_TOKEN": str(training_config.label_studio_token),
-            "LABEL_STUDIO_PROJECT_URL": str(training_config.label_studio_project_url),
-            "IMAGES_BUCKET_PATH": str(training_config.images_bucket_path),
-            "BUCKET_PATH": str(training_config.bucket_path),
+            "LABEL_STUDIO_URL": str(training_config.label_studio_url),
+            "LABEL_STUDIO_PROJECT_ID": str(training_config.label_studio_project_id),
             "NUMBER_OF_FOLDS": str(training_config.number_of_folds),
             "USE_KFOLD": str(training_config.use_kfold),
             "ACCELERATOR_COUNT": str(training_config.accelerator_count),
@@ -113,7 +115,10 @@ class CLI:
             "MLFLOW_EXPERIMENT_NAME": str(training_config.mlflow_experiment_name),
             "MLFLOW_RUN": str(training_config.mlflow_run),
             "MLFLOW_TRACKING_USERNAME": str(training_config.mlflow_tracking_username),
-            "MLFLOW_TRACKING_PASSWORD": str(training_config.mlflow_tracking_password)
+            "MLFLOW_TRACKING_PASSWORD": str(training_config.mlflow_tracking_password),
+            "SOURCE_IMAGES_BUCKET": str(training_config.source_images_bucket),
+            "SOURCE_IMAGES_DIRECTORY": str(training_config.source_images_directory),
+            "TRAINED_MODELS_BUCKET": str(training_config.trained_models_bucket),
         }
 
 
@@ -124,9 +129,8 @@ class TrainingConfig:
     model: str
     obb: bool
     label_studio_token: str
-    label_studio_project_url: str
-    images_bucket_path: str
-    bucket_path: str
+    label_studio_url: str
+    label_studio_project_id: str
     number_of_folds: int
     use_kfold: bool
     accelerator_count: int
@@ -135,6 +139,9 @@ class TrainingConfig:
     mlflow_run: str
     mlflow_tracking_username: str
     mlflow_tracking_password: str
+    source_images_bucket: str
+    source_images_directory: str
+    trained_models_bucket: str
 
 
 def main():

--- a/src/training_job.py
+++ b/src/training_job.py
@@ -14,7 +14,7 @@ class TrainingJob:
         self.accelerator_count = accelerator_count
         self.training_config = training_config
 
-        aiplatform.init(project=self.gc_project, staging_bucket=self.gc_bucket)
+        aiplatform.init(project=self.gc_project, staging_bucket=f"gs://{self.gc_bucket}")
 
         self.job = aiplatform.CustomTrainingJob(
             display_name=self.DEFAULT_JOB_NAME,
@@ -40,9 +40,8 @@ class TrainingJob:
             "MODEL": str(training_config.model),
             "OBB": str(training_config.obb),
             "LABEL_STUDIO_TOKEN": str(training_config.label_studio_token),
-            "LABEL_STUDIO_PROJECT_URL": str(training_config.label_studio_project_url),
-            "IMAGES_BUCKET_PATH": str(training_config.images_bucket_path),
-            "BUCKET_PATH": str(training_config.bucket_path),
+            "LABEL_STUDIO_URL": str(training_config.label_studio_url),
+            "LABEL_STUDIO_PROJECT_ID": str(training_config.label_studio_project_id),
             "NUMBER_OF_FOLDS": str(training_config.number_of_folds),
             "ACCELERATOR_COUNT": str(training_config.accelerator_count),
             "USE_KFOLD": str(training_config.use_kfold),
@@ -50,7 +49,10 @@ class TrainingJob:
             "MLFLOW_EXPERIMENT_NAME": str(training_config.mlflow_experiment_name),
             "MLFLOW_RUN": str(training_config.mlflow_run),
             "MLFLOW_TRACKING_USERNAME": str(training_config.mlflow_tracking_username),
-            "MLFLOW_TRACKING_PASSWORD": str(training_config.mlflow_tracking_password)
+            "MLFLOW_TRACKING_PASSWORD": str(training_config.mlflow_tracking_password),
+            "SOURCE_IMAGES_BUCKET": str(training_config.source_images_bucket),
+            "SOURCE_IMAGES_DIRECTORY": str(training_config.source_images_directory),
+            "TRAINED_MODELS_BUCKET": str(training_config.trained_models_bucket),
         }
 
     def _load_requirements(self) -> list[str]:


### PR DESCRIPTION
Now only the labeled images are downloaded from the bucket, instead of downloading ALL images and then filtering the labeled ones. This is faster when there are many images on the bucket.

Some `os` calls were also replaced by calls to libraries, which is faster and less prone to errors. Specifically for decompressing the YOLO zip file, and for getting the label config from LabelStudio.